### PR TITLE
fix: implementa a condicao 'if not exists'

### DIFF
--- a/init-database-pg.sql
+++ b/init-database-pg.sql
@@ -1,1 +1,4 @@
-create database if not exists portal_aulas_online;
+CREATE EXTENSION dblink;
+
+SELECT 'CREATE DATABASE portal_aulas_online'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'portal_aulas_online')\gexec


### PR DESCRIPTION
Estava dando erro ao executar o comando `sudo docker-compose up` por causa da sintaxe `if not exists`. Link da solução: https://stackoverflow.com/questions/18389124/simulate-create-database-if-not-exists-for-postgresql/36218838#36218838 .