### PR TITLE
51 criar seed para admin e roles

### DIFF
--- a/portal-aulas-api/manage.py
+++ b/portal-aulas-api/manage.py
@@ -16,7 +16,14 @@ def main():
             "forget to activate a virtual environment?"
         ) from exc
     execute_from_command_line(sys.argv)
+    
+
+def load_seed_data():
+    from django.core.management import call_command
+    call_command("loaddata", "seed/roles.json")
+    call_command("loaddata", "seed/admin.json")
 
 
 if __name__ == '__main__':
     main()
+    load_seed_data()

--- a/portal-aulas-api/seed/admin.json
+++ b/portal-aulas-api/seed/admin.json
@@ -7,7 +7,7 @@
             "email": "admin@gmail.com",
             "password": "123456",
             "about": "Admin user",
-            "role": [1,2,3],
+            "role": [3],
             "created": "2023-05-10T11:00:00-03:00",
             "modified": "2023-05-10T11:00:00-03:00"
         }

--- a/portal-aulas-api/seed/admin.json
+++ b/portal-aulas-api/seed/admin.json
@@ -1,0 +1,15 @@
+[
+    {
+        "model": "user.User",
+        "pk": 1,
+        "fields": {
+            "name": "Admin",
+            "email": "admin@gmail.com",
+            "password": "123456",
+            "about": "Admin user",
+            "role": [1,2,3],
+            "created": "2023-05-10T11:00:00-03:00",
+            "modified": "2023-05-10T11:00:00-03:00"
+        }
+    }
+]

--- a/portal-aulas-api/seed/roles.json
+++ b/portal-aulas-api/seed/roles.json
@@ -1,0 +1,23 @@
+[
+    {
+        "model": "user.Role",
+        "pk": 1,
+        "fields": {
+            "name": "STUDENT"
+        }
+    },
+    {
+        "model": "user.Role",
+        "pk": 2,
+        "fields": {
+            "name": "PROFESSOR"
+        }
+    },
+    {
+        "model": "user.Role",
+        "pk": 3,
+        "fields": {
+            "name": "ADMIN"
+        }
+    }
+]


### PR DESCRIPTION
Criando seed para User Admin e Roles inicias como ```STUDENT```, ```PROFESSOR``` e ```ADMIN```

- Não mudará nada para executar o projeto
- Assim que ele executa o runserver, passa pelo menage.py e roda o loader que foi criado nessa issue