### PR TITLE
64 b adicionar flag favoritado ao retorno da requisição

### DIFF
--- a/portal-aulas-api/courses/views.py
+++ b/portal-aulas-api/courses/views.py
@@ -11,6 +11,7 @@ from user import authentication, serializers
 
 class CourseViewSet(viewsets.ModelViewSet):
     queryset = Course.objects.all()
+    authentication_classes = (authentication.CustomUserAuthenticationWIthoutError,)
 
     # Sobreescrita para utilizar Serializadores diferêntes dependêndo do endpoint
     def get_serializer_class(self):
@@ -23,7 +24,17 @@ class CourseViewSet(viewsets.ModelViewSet):
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
         serializer = self.get_serializer(instance)
-        return Response(serializer.data)
+
+        if request.user and request.user.is_authenticated:
+            favorite_courses = request.user.favorite_courses.all()
+            favorited = instance in favorite_courses
+            data = serializer.data
+            data['favorited'] = favorited
+        else:
+            data = serializer.data
+
+        return Response(data)  
+            
     
     # [GET] /?page={int}&size={int}&professor={int}
     def list(self, request, *args, **kwargs):

--- a/portal-aulas-api/user/authentication.py
+++ b/portal-aulas-api/user/authentication.py
@@ -20,3 +20,19 @@ class CustomUserAuthentication(authentication.BaseAuthentication):
         user = models.User.objects.filter(id=payload["id"]).first()
 
         return (user, None)
+
+class CustomUserAuthenticationWIthoutError(authentication.BaseAuthentication):
+     def authenticate(self, request):
+        token = request.headers.get('jwt')
+
+        if token is None:
+            return None  # Retorna None se o token não estiver presente
+
+        try:
+            payload = jwt.decode(token, settings.JWT_SECRET, algorithms=["HS256"])
+            user = models.User.objects.filter(id=payload["id"]).first()
+            return (user, None)
+        except jwt.ExpiredSignatureError:
+            return None, {"message": "Token de autenticação expirado"}
+        except jwt.InvalidTokenError:
+            return None, {"message": "Token de autenticação inválido"}


### PR DESCRIPTION
Adicionando nova flag ao retorno da requisição de pegar um curso por id:

```favorited: true | false```

Rota: GET ```{{host}}/courses/courses/:course_id```

- Agora está verificando se o usuário autenticado favoritou o curso selecionado
- Criei uma nova classe de autenticação que não retorna erro se requisitar a rota sem passar o jwt

retorno quando autenticado: 
```json
{
    "id": 2,
    "title": "tes te 123123",
    "description": "e werw esda sadfdsafsdf sdfsdfs sdfq ffdasfv gt c sdsd f",
    "banner": "http://localhost:8080/media/images/courses/2725cb0db84d4f029ca7e2259754febd.png",
    "content": "12321 31 sdf sfcsd fsdf",
    "professor": {
        "id": 2,
        "name": "Iago Professor"
    },
    "learnings": [],
    "students": [],
    "lessons": [],
    "favorited": true
}
```