### PR TITLE
Adicionar ordenamento drag and drop aulas e correção pagina detalhes

### DIFF
--- a/portal-aulas-api/.dockerignore
+++ b/portal-aulas-api/.dockerignore
@@ -1,1 +1,1 @@
-media/
+# media/

--- a/portal-aulas-api/courses/serializers/category.py
+++ b/portal-aulas-api/courses/serializers/category.py
@@ -17,6 +17,7 @@ class CourseCategorySerializerForGETS(serializers.ModelSerializer):
     class Meta:
         model = CourseCategory
         fields = ['id', 'name', 'lessons_order', 'lessons']
+        depth=1
 
 class CourseCategorySerializerForPOSTS(serializers.ModelSerializer):
     lessons_order = serializers.ListField(child=serializers.IntegerField())

--- a/portal-aulas-api/lessons/views.py
+++ b/portal-aulas-api/lessons/views.py
@@ -20,6 +20,7 @@ import re
 import mimetypes
 from .tools import generate_certificate
 import datetime
+import json
 
 from django.http import HttpResponse
 from reportlab.lib.pagesizes import letter
@@ -121,6 +122,11 @@ class LessonViewSet(viewsets.ModelViewSet):
                 lesson.category = categories[0]
                 lesson.save()
 
+        categories_order = json.loads(lesson.category.lessons_order)
+        categories_order.append(lesson.id)
+
+        lesson.category.lessons_order = json.dumps(categories_order)
+        lesson.category.save()
 
 
         if 'banner' not in request.data and lesson.video is not None:


### PR DESCRIPTION
Implementação da #94  backend com a funcionalidades necessárias para implementação da https://github.com/349Team/portal-aulas-online-frontend/issues/130 no frontend.

Foram realizada mudanças no serializer de aula e nos endpoints de categoria para suportar a ordenação das aulas através das `lessons_order` em categoria, além de alterações para corrigir o retorno de `prev_lesson` e `next_lesson` para levar em consideração apenas aulas pertencentes à mesma categoria.

**Total:** 2 horas